### PR TITLE
Phase1 add typescript

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SwingTrader - Trading Journal</title>
-    <script type="module" crossorigin src="/assets/index-8ea10112.js"></script>
+    <title>SAR Trading Journal</title>
+    <script type="module" crossorigin src="/assets/index-1cdc1a66.js"></script>
     <link rel="stylesheet" href="/assets/index-cf69bddb.css">
   </head>
   <body>

--- a/frontend/src/services/accountService.ts
+++ b/frontend/src/services/accountService.ts
@@ -1,4 +1,7 @@
-import { AccountSettings } from './types';
+import { AccountSettings } from '../types/api';
+
+// Re-export for backward compatibility
+export type { AccountSettings };
 
 /**
  * Account Settings Service

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,54 +1,15 @@
 // src/services/authService.ts
-import api, { API_URL } from './apiConfig';
+import api from './apiConfig';
+import { 
+  User, 
+  LoginData, 
+  RegisterData, 
+  AuthResponse,
+  AxiosErrorResponse 
+} from '../types/api';
 
-export interface User {
-  id: number;
-  username: string;
-  email: string;
-  is_active: boolean;
-  created_at: string;
-  first_name?: string;
-  last_name?: string;
-  display_name?: string;
-  bio?: string;
-  profile_picture_url?: string;
-  updated_at?: string;
-  timezone?: string;
-  
-  // Notification settings
-  email_notifications_enabled?: boolean;
-  daily_email_enabled?: boolean;
-  daily_email_time?: string;
-  weekly_email_enabled?: boolean;
-  weekly_email_time?: string;
-  
-  // 2FA status
-  two_factor_enabled?: boolean;
-  
-  // Trading settings
-  default_account_size?: number;
-  current_account_balance?: number;
-  initial_account_balance?: number;
-  
-  // Admin system
-  role?: string; // 'STUDENT' or 'INSTRUCTOR'
-}
-
-export interface LoginData {
-  username: string;
-  password: string;
-}
-
-export interface RegisterData {
-  username: string;
-  email: string;
-  password: string;
-}
-
-export interface AuthResponse {
-  access_token: string;
-  token_type: string;
-}
+// Re-export types for backward compatibility
+export type { User, LoginData, RegisterData, AuthResponse };
 
 // Login user and return token
 export const login = async (username: string, password: string): Promise<AuthResponse> => {
@@ -65,9 +26,10 @@ export const login = async (username: string, password: string): Promise<AuthRes
     });
     
     return response.data;
-  } catch (error: any) {
-    console.error('Login error:', error);
-    if (error.response?.status === 401) {
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Login error:', axiosError);
+    if (axiosError.response?.status === 401) {
       throw new Error('Invalid username or password');
     }
     throw new Error('Login failed. Please try again.');
@@ -79,10 +41,11 @@ export const register = async (userData: RegisterData): Promise<User> => {
   try {
     const response = await api.post('/api/auth/register', userData);
     return response.data;
-  } catch (error: any) {
-    console.error('Registration error:', error);
-    if (error.response?.status === 400) {
-      throw new Error(error.response.data.detail || 'Registration failed');
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Registration error:', axiosError);
+    if (axiosError.response?.status === 400) {
+      throw new Error(axiosError.response.data.detail || 'Registration failed');
     }
     throw new Error('Registration failed. Please try again.');
   }
@@ -93,8 +56,9 @@ export const getCurrentUser = async (): Promise<User> => {
   try {
     const response = await api.get('/api/users/me');
     return response.data;
-  } catch (error: any) {
-    console.error('Get current user error:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Get current user error:', axiosError);
     throw new Error('Failed to get user profile');
   }
 };

--- a/frontend/src/services/debugService.ts
+++ b/frontend/src/services/debugService.ts
@@ -1,7 +1,13 @@
 // src/services/debugService.ts
 import api from './apiConfig';
+import { 
+  ApiConnectionStatus, 
+  AuthStatusResponse, 
+  AnalyticsDebugData,
+  AxiosErrorResponse 
+} from '../types/api';
 
-export const testApiConnection = async (): Promise<{status: string, message: string}> => {
+export const testApiConnection = async (): Promise<ApiConnectionStatus> => {
   try {
     console.log('Testing API connection...');
     const response = await api.get('/api/debug');
@@ -10,28 +16,30 @@ export const testApiConnection = async (): Promise<{status: string, message: str
       status: 'success',
       message: `API connection successful: ${response.data.message}`
     };
-  } catch (error: any) {
-    console.error('API connection test failed:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('API connection test failed:', axiosError);
     return {
       status: 'error',
-      message: `API connection failed: ${error.message}`
+      message: `API connection failed: ${axiosError.message}`
     };
   }
 };
 
-export const debugAnalyticsData = async (): Promise<any> => {
+export const debugAnalyticsData = async (): Promise<AnalyticsDebugData> => {
   try {
     console.log('Fetching analytics debug data...');
     const response = await api.get('/api/debug/analytics-data');
     console.log('Analytics debug data:', response.data);
     return response.data;
-  } catch (error: any) {
-    console.error('Failed to fetch analytics debug data:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Failed to fetch analytics debug data:', axiosError);
     throw error;
   }
 };
 
-export const checkAuthStatus = async (): Promise<any> => {
+export const checkAuthStatus = async (): Promise<AuthStatusResponse> => {
   try {
     console.log('Checking authentication status...');
     
@@ -54,19 +62,21 @@ export const checkAuthStatus = async (): Promise<any> => {
         tokenExists: true,
         tokenValue: token.substring(0, 10) + '...' // Show only part of the token for security
       };
-    } catch (error: any) {
+    } catch (error) {
+      const axiosError = error as AxiosErrorResponse;
       return {
         status: 'error',
-        message: `Authentication token may be invalid: ${error.message}`,
+        message: `Authentication token may be invalid: ${axiosError.message}`,
         tokenExists: true,
-        error: error.message
+        error: axiosError.message
       };
     }
-  } catch (error: any) {
-    console.error('Auth status check failed:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Auth status check failed:', axiosError);
     return {
       status: 'error',
-      message: `Failed to check auth status: ${error.message}`
+      message: `Failed to check auth status: ${axiosError.message}`
     };
   }
 };

--- a/frontend/src/services/imageService.ts
+++ b/frontend/src/services/imageService.ts
@@ -1,15 +1,11 @@
 import { API_URL } from './apiConfig';
+import {
+  ImageUploadResponse,
+  ImageUpdateResponse
+} from '../types/api';
 
-export interface ImageUploadResponse {
-  success: boolean;
-  image_url: string;
-  filename: string;
-}
-
-export interface ImageUpdateResponse {
-  success: boolean;
-  message: string;
-}
+// Re-export types for backward compatibility
+export type { ImageUploadResponse, ImageUpdateResponse };
 
 class ImageService {
   private baseUrl = `${API_URL}/api/images`;

--- a/frontend/src/services/importService.ts
+++ b/frontend/src/services/importService.ts
@@ -1,36 +1,9 @@
 // src/services/importService.ts
 import api from './apiConfig';
+import { ValidationError, ValidationResult, ImportResult } from '../types/api';
 
-export interface ValidationError {
-  type: string;
-  message: string;
-  details?: any;
-}
-
-export interface ValidationResult {
-  valid: boolean;
-  total_events: number;
-  filled_events?: number;
-  pending_events?: number;
-  unique_symbols: number;
-  date_range: {
-    earliest: string | null;
-    latest: string | null;
-  };
-  errors: ValidationError[];
-  warnings: ValidationError[];
-}
-
-export interface ImportResult {
-  success: boolean;
-  message: string;
-  stats?: {
-    positionsProcessed: number;
-    eventsCreated: number;
-    duration: number;
-  };
-  errors?: string[];
-}
+// Re-export types for backward compatibility
+export type { ValidationError, ValidationResult, ImportResult };
 
 /**
  * Validate a CSV file before importing

--- a/frontend/src/services/journalService.ts
+++ b/frontend/src/services/journalService.ts
@@ -1,36 +1,18 @@
 import { API_URL } from './apiConfig';
+import {
+  JournalEntry,
+  JournalEntryCreate,
+  JournalEntryUpdate,
+  JournalResponse
+} from '../types/api';
 
-export interface JournalEntry {
-  id: number;
-  entry_type: 'note' | 'lesson' | 'mistake' | 'analysis';
-  content: string;
-  entry_date: string;
-  created_at: string;
-  updated_at: string;
-  attached_images?: Array<{ url: string; description: string }>;
-  attached_charts?: number[];
-}
-
-export interface JournalEntryCreate {
-  entry_type: 'note' | 'lesson' | 'mistake' | 'analysis';
-  content: string;
-  entry_date?: string; // Optional, defaults to now
-  attached_images?: Array<{ url: string; description: string }>;
-  attached_charts?: number[];
-}
-
-export interface JournalEntryUpdate {
-  entry_type?: 'note' | 'lesson' | 'mistake' | 'analysis';
-  content?: string;
-  entry_date?: string;
-  attached_images?: Array<{ url: string; description: string }>;
-  attached_charts?: number[];
-}
-
-export interface JournalResponse {
-  success?: boolean;
-  message?: string;
-}
+// Re-export types for backward compatibility
+export type {
+  JournalEntry,
+  JournalEntryCreate,
+  JournalEntryUpdate,
+  JournalResponse
+};
 
 class JournalService {
   private baseUrl = `${API_URL}/api/v2`;

--- a/frontend/src/services/notesService.ts
+++ b/frontend/src/services/notesService.ts
@@ -1,9 +1,8 @@
 import { API_URL } from './apiConfig';
+import { NotesUpdateResponse } from '../types/api';
 
-export interface NotesUpdateResponse {
-  success: boolean;
-  message: string;
-}
+// Re-export types for backward compatibility
+export type { NotesUpdateResponse };
 
 class NotesService {
   private baseUrl = `${API_URL}/api/notes`;

--- a/frontend/src/services/notificationService.ts
+++ b/frontend/src/services/notificationService.ts
@@ -1,27 +1,25 @@
 // src/services/notificationService.ts
 import api from './apiConfig';
+import { 
+  NotificationSettings, 
+  TwoFactorSetup, 
+  BackupCodesResponse,
+  AxiosErrorResponse 
+} from '../types/api';
 
-export interface NotificationSettings {
-  email_notifications_enabled: boolean;
-  weekly_email_enabled: boolean;
-  weekly_email_time?: string;
-}
-
-export interface TwoFactorSetup {
-  secret: string;
-  qr_code: string;
-  backup_codes: string[];
-}
+// Re-export types for backward compatibility
+export type { NotificationSettings, TwoFactorSetup };
 
 // Update notification settings
 export const updateNotificationSettings = async (settings: NotificationSettings) => {
   try {
     const response = await api.put('/api/users/me/notifications', settings);
     return response.data;
-  } catch (error: any) {
-    console.error('Update notification settings error:', error);
-    if (error.response?.status === 400) {
-      throw new Error(error.response.data.detail || 'Failed to update notification settings');
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Update notification settings error:', axiosError);
+    if (axiosError.response?.status === 400) {
+      throw new Error(axiosError.response.data.detail || 'Failed to update notification settings');
     }
     throw new Error('Failed to update notification settings. Please try again.');
   }
@@ -32,8 +30,9 @@ export const setup2FA = async (): Promise<TwoFactorSetup> => {
   try {
     const response = await api.post('/api/users/me/2fa/setup');
     return response.data;
-  } catch (error: any) {
-    console.error('2FA setup error:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('2FA setup error:', axiosError);
     throw new Error('Failed to set up 2FA. Please try again.');
   }
 };
@@ -42,10 +41,11 @@ export const setup2FA = async (): Promise<TwoFactorSetup> => {
 export const verify2FA = async (token: string): Promise<void> => {
   try {
     await api.post('/api/users/me/2fa/verify', { token });
-  } catch (error: any) {
-    console.error('2FA verification error:', error);
-    if (error.response?.status === 400) {
-      throw new Error(error.response.data.detail || 'Invalid verification code');
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('2FA verification error:', axiosError);
+    if (axiosError.response?.status === 400) {
+      throw new Error(axiosError.response.data.detail || 'Invalid verification code');
     }
     throw new Error('Failed to verify 2FA. Please try again.');
   }
@@ -55,8 +55,9 @@ export const verify2FA = async (token: string): Promise<void> => {
 export const disable2FA = async (): Promise<void> => {
   try {
     await api.delete('/api/users/me/2fa');
-  } catch (error: any) {
-    console.error('2FA disable error:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('2FA disable error:', axiosError);
     throw new Error('Failed to disable 2FA. Please try again.');
   }
 };
@@ -64,10 +65,11 @@ export const disable2FA = async (): Promise<void> => {
 // Regenerate backup codes
 export const regenerateBackupCodes = async (): Promise<string[]> => {
   try {
-    const response = await api.post('/api/users/me/2fa/backup-codes');
+    const response = await api.post<BackupCodesResponse>('/api/users/me/2fa/backup-codes');
     return response.data.backup_codes;
-  } catch (error: any) {
-    console.error('Regenerate backup codes error:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Regenerate backup codes error:', axiosError);
     throw new Error('Failed to regenerate backup codes. Please try again.');
   }
 };

--- a/frontend/src/services/positionsService.ts
+++ b/frontend/src/services/positionsService.ts
@@ -1,4 +1,28 @@
 import api from './apiConfig';
+import {
+  Position,
+  PositionEvent,
+  PositionDetails,
+  CreatePositionData,
+  AddEventData,
+  EventUpdateData,
+  PositionUpdateData,
+  PendingOrder,
+  CacheEntry,
+  PartialExit
+} from '../types/api';
+
+// Re-export types for backward compatibility
+export type {
+  Position,
+  PositionEvent,
+  PositionDetails,
+  CreatePositionData,
+  AddEventData,
+  EventUpdateData,
+  PositionUpdateData,
+  PendingOrder
+};
 
 // =====================================================
 // NEW UNIFIED POSITIONS SERVICE 
@@ -7,10 +31,10 @@ import api from './apiConfig';
 // =====================================================
 
 // Simple in-memory cache for performance
-const cache = new Map<string, { data: any; timestamp: number; ttl: number }>();
+const cache = new Map<string, CacheEntry<unknown>>();
 const CACHE_TTL = 30000; // 30 seconds cache TTL
 
-function getCacheKey(endpoint: string, params?: any): string {
+function getCacheKey(endpoint: string, params?: Record<string, unknown>): string {
   return `${endpoint}_${JSON.stringify(params || {})}`;
 }
 
@@ -34,114 +58,6 @@ function clearPositionsCache(): void {
       cache.delete(key);
     }
   }
-}
-
-// Core interfaces that match our new API
-export interface Position {
-  id: number;
-  ticker: string;
-  instrument_type?: 'STOCK' | 'OPTIONS';
-  strategy?: string;
-  setup_type?: string;
-  timeframe?: string;
-  status: 'open' | 'closed';
-  current_shares: number;
-  avg_entry_price?: number;
-  total_cost: number;
-  total_realized_pnl: number;
-  current_stop_loss?: number;
-  current_take_profit?: number;
-  opened_at: string;
-  closed_at?: string;
-  notes?: string;
-  lessons?: string;
-  mistakes?: string;
-  events_count: number;
-  return_percent?: number; // Return percentage for closed positions
-  original_risk_percent?: number; // Original risk % when opened
-  current_risk_percent?: number;  // Current risk % based on current stop
-  original_shares?: number;       // Shares when position opened
-  account_value_at_entry?: number; // Account value when opened
-  // Options-specific fields
-  strike_price?: number;
-  expiration_date?: string;
-  option_type?: 'CALL' | 'PUT';
-}
-
-export interface PositionEvent {
-  id: number;
-  event_type: 'buy' | 'sell';
-  event_date: string;
-  shares: number;
-  price: number;
-  stop_loss?: number;
-  take_profit?: number;
-  notes?: string;
-  source: string;
-  realized_pnl?: number;
-  position_shares_before?: number;
-  position_shares_after?: number;
-}
-
-export interface PendingOrder {
-  id: number;
-  symbol: string;
-  side: string; // Buy/Sell
-  status: string; // pending/cancelled/etc
-  shares: number;
-  price?: number;
-  order_type?: string;
-  placed_time: string;
-  stop_loss?: number;
-  take_profit?: number;
-  notes?: string;
-}
-
-export interface PositionDetails {
-  position: Position;
-  events: PositionEvent[];
-  metrics: {
-    total_bought: number;
-    total_sold: number;
-    avg_buy_price: number;
-    avg_sell_price: number;
-    realized_pnl: number;
-    current_value: number;
-    total_events: number;
-  };
-}
-
-export interface CreatePositionData {
-  ticker: string;
-  instrument_type?: 'STOCK' | 'OPTIONS';
-  strategy?: string;
-  setup_type?: string;
-  timeframe?: string;
-  notes?: string;
-  account_balance_at_entry?: number;  // Account balance when position is created
-  // Options-specific fields
-  strike_price?: number;
-  expiration_date?: string;
-  option_type?: 'CALL' | 'PUT';
-  initial_event: {
-    event_type: 'buy';
-    shares: number;
-    price: number;
-    event_date?: string;
-    stop_loss?: number;
-    take_profit?: number;
-    notes?: string;
-  };
-}
-
-export interface AddEventData {
-  event_type: 'buy' | 'sell';
-  shares: number;
-  price: number;
-  event_date?: string;
-  stop_loss?: number;
-  take_profit?: number;
-  notes?: string;
 }
 
 // =====================================================
@@ -434,7 +350,7 @@ export async function getAllPositionsForAnalytics(): Promise<Position[]> {
  * Transform Position to legacy Trade interface for gradual migration
  * This allows existing components to work while we migrate them
  */
-export function positionToLegacyTrade(position: Position): any {
+export function positionToLegacyTrade(position: Position): Record<string, unknown> {
   return {
     id: position.id,
     ticker: position.ticker,
@@ -457,7 +373,7 @@ export function positionToLegacyTrade(position: Position): any {
 /**
  * Transform PositionEvent to legacy PartialExit interface
  */
-export function eventToPartialExit(event: PositionEvent): any {
+export function eventToPartialExit(event: PositionEvent): PartialExit | null {
   if (event.event_type !== 'sell') return null;
   
   return {

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -2,81 +2,11 @@
 export type InstrumentType = 'stock' | 'options';
 export type OptionType = 'call' | 'put';
 
-// Interface for account settings
-export interface AccountSettings {
-  starting_balance: number;
-  current_balance: number;
-  last_updated: string;
-}
-
-// Interface for partial exits
-export interface PartialExit {
-  exit_price: number;
-  exit_date: string;
-  shares_sold: number;
-  profit_loss: number;
-  notes?: string;
-}
-
-// Interface for API trade data
-export interface ApiTrade {
-  id: number;
-  ticker: string;
-  trade_type: 'long' | 'short';
-  status: 'planned' | 'active' | 'closed' | 'canceled' | 'Open' | 'Closed';
-  
-  // Instrument type and options details
-  instrument_type: InstrumentType;
-  strike_price?: number;  // Options only
-  expiration_date?: string;  // Options only
-  option_type?: OptionType;  // Options only (call/put)
-  
-  entry_price: number;
-  entry_date: string;
-  entry_notes?: string;
-  exit_price?: number;
-  exit_date?: string;
-  exit_notes?: string;
-  position_size: number;
-  stop_loss: number;
-  take_profit?: number;
-  risk_per_share: number;
-  total_risk: number;
-  profit_loss?: number;
-  profit_loss_percent?: number;
-  strategy: string;
-  setup_type: string;
-  timeframe: string;
-  market_conditions?: string;
-  tags?: string[];
-  partial_exits?: PartialExit[];
-}
-
-// Interface for frontend trade data (extends API data with display fields)
-export interface Trade extends ApiTrade {
-  displayStatus: string;
-  displayDirection: string;
-  displayDate: string;
-  remaining_shares?: number;
-  position_value?: number;
-  risk_reward_ratio?: number;
-  mistakes?: string;
-  lessons?: string;
-}
-
-// Interface for dashboard metrics
-export interface DashboardData {
-  totalTrades: number;
-  openTrades: number;
-  winRate: number;
-  profitLoss: number;
-  equityCurve: Array<{ date: string; equity: number }>;
-  setupPerformance: Array<{ name: string; value: number; color: string }>;
-  recentTrades: Array<{
-    id: number;
-    ticker: string;
-    entryDate: string;
-    status: string;
-    profitLoss: number | null;
-  }>;
-}
+// Re-export all types from the central api.ts file
+export type {
+  AccountSettings,
+  PartialExit,
+  ApiTrade,
+  Trade,
+  DashboardData
+} from '../types/api';

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -1,29 +1,25 @@
 // src/services/userService.ts
 import api from './apiConfig';
-import { User } from './authService';
+import { 
+  User, 
+  UserUpdateData, 
+  ChangePasswordData, 
+  UserExportData,
+  ProfilePictureUploadResponse,
+  AxiosErrorResponse 
+} from '../types/api';
 
-export interface UserUpdateData {
-  first_name?: string;
-  last_name?: string;
-  display_name?: string;
-  bio?: string;
-  email?: string;
-  timezone?: string;
-  default_account_size?: number;
-}
-
-export interface ChangePasswordData {
-  current_password: string;
-  new_password: string;
-}
+// Re-export types for backward compatibility
+export type { UserUpdateData, ChangePasswordData };
 
 // Get current user profile
 export const getCurrentUser = async (): Promise<User> => {
   try {
     const response = await api.get('/api/users/me');
     return response.data;
-  } catch (error: any) {
-    console.error('Get current user error:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Get current user error:', axiosError);
     throw new Error('Failed to get user profile. Please try again.');
   }
 };
@@ -33,10 +29,11 @@ export const updateProfile = async (userData: UserUpdateData): Promise<User> => 
   try {
     const response = await api.put('/api/users/me', userData);
     return response.data;
-  } catch (error: any) {
-    console.error('Update profile error:', error);
-    if (error.response?.status === 400) {
-      throw new Error(error.response.data.detail || 'Failed to update profile');
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Update profile error:', axiosError);
+    if (axiosError.response?.status === 400) {
+      throw new Error(axiosError.response.data.detail || 'Failed to update profile');
     }
     throw new Error('Failed to update profile. Please try again.');
   }
@@ -46,22 +43,24 @@ export const updateProfile = async (userData: UserUpdateData): Promise<User> => 
 export const changePassword = async (passwordData: ChangePasswordData): Promise<void> => {
   try {
     await api.put('/api/users/me/password', passwordData);
-  } catch (error: any) {
-    console.error('Change password error:', error);
-    if (error.response?.status === 400) {
-      throw new Error(error.response.data.detail || 'Failed to change password');
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Change password error:', axiosError);
+    if (axiosError.response?.status === 400) {
+      throw new Error(axiosError.response.data.detail || 'Failed to change password');
     }
     throw new Error('Failed to change password. Please try again.');
   }
 };
 
 // Export user data
-export const exportUserData = async (): Promise<any> => {
+export const exportUserData = async (): Promise<UserExportData> => {
   try {
     const response = await api.get('/api/users/me/export');
     return response.data;
-  } catch (error: any) {
-    console.error('Export user data error:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Export user data error:', axiosError);
     throw new Error('Failed to export user data. Please try again.');
   }
 };
@@ -70,8 +69,9 @@ export const exportUserData = async (): Promise<any> => {
 export const deleteUserAccount = async (): Promise<void> => {
   try {
     await api.delete('/api/users/me');
-  } catch (error: any) {
-    console.error('Delete account error:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Delete account error:', axiosError);
     throw new Error('Failed to delete account. Please try again.');
   }
 };
@@ -80,14 +80,15 @@ export const deleteUserAccount = async (): Promise<void> => {
 export const clearAllUserData = async (): Promise<void> => {
   try {
     await api.delete('/api/users/me/data');
-  } catch (error: any) {
-    console.error('Clear all data error:', error);
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Clear all data error:', axiosError);
     throw new Error('Failed to clear user data. Please try again.');
   }
 };
 
 // Upload profile picture
-export const uploadProfilePicture = async (file: File): Promise<{ profile_picture_url: string }> => {
+export const uploadProfilePicture = async (file: File): Promise<ProfilePictureUploadResponse> => {
   try {
     const formData = new FormData();
     formData.append('file', file);
@@ -99,10 +100,11 @@ export const uploadProfilePicture = async (file: File): Promise<{ profile_pictur
     });
     
     return response.data;
-  } catch (error: any) {
-    console.error('Upload profile picture error:', error);
-    if (error.response?.status === 400) {
-      throw new Error(error.response.data.detail || 'Failed to upload profile picture');
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Upload profile picture error:', axiosError);
+    if (axiosError.response?.status === 400) {
+      throw new Error(axiosError.response.data.detail || 'Failed to upload profile picture');
     }
     throw new Error('Failed to upload profile picture. Please try again.');
   }
@@ -112,9 +114,10 @@ export const uploadProfilePicture = async (file: File): Promise<{ profile_pictur
 export const deleteProfilePicture = async (): Promise<void> => {
   try {
     await api.delete('/api/users/me/profile-picture');
-  } catch (error: any) {
-    console.error('Delete profile picture error:', error);
-    if (error.response?.status === 404) {
+  } catch (error) {
+    const axiosError = error as AxiosErrorResponse;
+    console.error('Delete profile picture error:', axiosError);
+    if (axiosError.response?.status === 404) {
       throw new Error('No profile picture to delete');
     }
     throw new Error('Failed to delete profile picture. Please try again.');

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,527 @@
+/**
+ * Comprehensive TypeScript interfaces for all API responses and data types
+ * This file eliminates the use of 'any' types throughout the application
+ */
+
+// =====================================================
+// ERROR TYPES
+// =====================================================
+
+export interface ApiError {
+  detail?: string;
+  message?: string;
+  status?: number;
+}
+
+export interface AxiosErrorResponse {
+  response?: {
+    status: number;
+    data: ApiError;
+    statusText?: string;
+  };
+  message: string;
+  code?: string;
+}
+
+export interface ValidationError {
+  type: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+// =====================================================
+// AUTH & USER TYPES
+// =====================================================
+
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  is_active: boolean;
+  created_at: string;
+  first_name?: string;
+  last_name?: string;
+  display_name?: string;
+  bio?: string;
+  profile_picture_url?: string;
+  updated_at?: string;
+  timezone?: string;
+  
+  // Notification settings
+  email_notifications_enabled?: boolean;
+  daily_email_enabled?: boolean;
+  daily_email_time?: string;
+  weekly_email_enabled?: boolean;
+  weekly_email_time?: string;
+  
+  // 2FA status
+  two_factor_enabled?: boolean;
+  
+  // Trading settings
+  default_account_size?: number;
+  current_account_balance?: number;
+  initial_account_balance?: number;
+  
+  // Admin system
+  role?: 'STUDENT' | 'INSTRUCTOR';
+}
+
+export interface LoginData {
+  username: string;
+  password: string;
+}
+
+export interface RegisterData {
+  username: string;
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse {
+  access_token: string;
+  token_type: string;
+}
+
+export interface UserUpdateData {
+  first_name?: string;
+  last_name?: string;
+  display_name?: string;
+  bio?: string;
+  email?: string;
+  timezone?: string;
+  default_account_size?: number;
+}
+
+export interface ChangePasswordData {
+  current_password: string;
+  new_password: string;
+}
+
+export interface UserExportData {
+  user: User;
+  positions: Position[];
+  events: PositionEvent[];
+  journal_entries: JournalEntry[];
+  export_date: string;
+}
+
+// =====================================================
+// TRADING TYPES
+// =====================================================
+
+export type InstrumentType = 'stock' | 'options' | 'STOCK' | 'OPTIONS';
+export type OptionType = 'call' | 'put' | 'CALL' | 'PUT';
+export type TradeType = 'long' | 'short';
+export type TradeStatus = 'planned' | 'active' | 'closed' | 'canceled' | 'Open' | 'Closed' | 'open';
+
+// =====================================================
+// ACCOUNT SETTINGS
+// =====================================================
+
+export interface AccountSettings {
+  starting_balance: number;
+  current_balance: number;
+  last_updated: string;
+}
+
+// =====================================================
+// POSITION TYPES
+// =====================================================
+
+export interface Position {
+  id: number;
+  ticker: string;
+  instrument_type?: 'STOCK' | 'OPTIONS';
+  strategy?: string;
+  setup_type?: string;
+  timeframe?: string;
+  status: 'open' | 'closed';
+  current_shares: number;
+  avg_entry_price?: number;
+  total_cost: number;
+  total_realized_pnl: number;
+  current_stop_loss?: number;
+  current_take_profit?: number;
+  opened_at: string;
+  closed_at?: string;
+  notes?: string;
+  lessons?: string;
+  mistakes?: string;
+  events_count: number;
+  return_percent?: number;
+  original_risk_percent?: number;
+  current_risk_percent?: number;
+  original_shares?: number;
+  account_value_at_entry?: number;
+  // Options-specific fields
+  strike_price?: number;
+  expiration_date?: string;
+  option_type?: 'CALL' | 'PUT';
+  // Optional event history
+  events?: PositionEvent[];
+}
+
+export interface PositionEvent {
+  id: number;
+  event_type: 'buy' | 'sell';
+  event_date: string;
+  shares: number;
+  price: number;
+  stop_loss?: number;
+  take_profit?: number;
+  notes?: string;
+  source: string;
+  realized_pnl?: number;
+  position_shares_before?: number;
+  position_shares_after?: number;
+}
+
+export interface PositionDetails {
+  position: Position;
+  events: PositionEvent[];
+  metrics: {
+    total_bought: number;
+    total_sold: number;
+    avg_buy_price: number;
+    avg_sell_price: number;
+    realized_pnl: number;
+    current_value: number;
+    total_events: number;
+  };
+}
+
+export interface CreatePositionData {
+  ticker: string;
+  instrument_type?: 'STOCK' | 'OPTIONS';
+  strategy?: string;
+  setup_type?: string;
+  timeframe?: string;
+  notes?: string;
+  account_balance_at_entry?: number;
+  // Options-specific fields
+  strike_price?: number;
+  expiration_date?: string;
+  option_type?: 'CALL' | 'PUT';
+  initial_event: {
+    event_type: 'buy';
+    shares: number;
+    price: number;
+    event_date?: string;
+    stop_loss?: number;
+    take_profit?: number;
+    notes?: string;
+  };
+}
+
+export interface AddEventData {
+  event_type: 'buy' | 'sell';
+  shares: number;
+  price: number;
+  event_date?: string;
+  stop_loss?: number;
+  take_profit?: number;
+  notes?: string;
+}
+
+export interface EventUpdateData {
+  shares?: number;
+  price?: number;
+  event_date?: string;
+  stop_loss?: number | null;
+  take_profit?: number | null;
+  notes?: string;
+}
+
+export interface PositionUpdateData {
+  strategy?: string;
+  setup_type?: string;
+  timeframe?: string;
+  notes?: string;
+  lessons?: string;
+  mistakes?: string;
+}
+
+// =====================================================
+// LEGACY TRADE TYPES (for gradual migration)
+// =====================================================
+
+export interface PartialExit {
+  exit_price: number;
+  exit_date: string;
+  shares_sold: number;
+  profit_loss: number;
+  notes?: string;
+}
+
+export interface ApiTrade {
+  id: number;
+  ticker: string;
+  trade_type: TradeType;
+  status: TradeStatus;
+  instrument_type: InstrumentType;
+  strike_price?: number;
+  expiration_date?: string;
+  option_type?: OptionType;
+  entry_price: number;
+  entry_date: string;
+  entry_notes?: string;
+  exit_price?: number;
+  exit_date?: string;
+  exit_notes?: string;
+  position_size: number;
+  stop_loss: number;
+  take_profit?: number;
+  risk_per_share: number;
+  total_risk: number;
+  profit_loss?: number;
+  profit_loss_percent?: number;
+  strategy: string;
+  setup_type: string;
+  timeframe: string;
+  market_conditions?: string;
+  tags?: string[];
+  partial_exits?: PartialExit[];
+}
+
+export interface Trade extends ApiTrade {
+  displayStatus: string;
+  displayDirection: string;
+  displayDate: string;
+  remaining_shares?: number;
+  position_value?: number;
+  risk_reward_ratio?: number;
+  mistakes?: string;
+  lessons?: string;
+}
+
+// =====================================================
+// PENDING ORDERS
+// =====================================================
+
+export interface PendingOrder {
+  id: number;
+  symbol: string;
+  side: string;
+  status: string;
+  shares: number;
+  price?: number;
+  order_type?: string;
+  placed_time: string;
+  stop_loss?: number;
+  take_profit?: number;
+  notes?: string;
+}
+
+// =====================================================
+// JOURNAL TYPES
+// =====================================================
+
+export type JournalEntryType = 'note' | 'lesson' | 'mistake' | 'analysis';
+
+export interface JournalEntry {
+  id: number;
+  entry_type: JournalEntryType;
+  content: string;
+  entry_date: string;
+  created_at: string;
+  updated_at: string;
+  attached_images?: Array<{ url: string; description: string }>;
+  attached_charts?: number[];
+}
+
+export interface JournalEntryCreate {
+  entry_type: JournalEntryType;
+  content: string;
+  entry_date?: string;
+  attached_images?: Array<{ url: string; description: string }>;
+  attached_charts?: number[];
+}
+
+export interface JournalEntryUpdate {
+  entry_type?: JournalEntryType;
+  content?: string;
+  entry_date?: string;
+  attached_images?: Array<{ url: string; description: string }>;
+  attached_charts?: number[];
+}
+
+export interface JournalResponse {
+  success?: boolean;
+  message?: string;
+}
+
+// =====================================================
+// IMAGE & MEDIA TYPES
+// =====================================================
+
+export interface ImageUploadResponse {
+  success: boolean;
+  image_url: string;
+  filename: string;
+}
+
+export interface ImageUpdateResponse {
+  success: boolean;
+  message: string;
+}
+
+// =====================================================
+// NOTIFICATION TYPES
+// =====================================================
+
+export interface NotificationSettings {
+  email_notifications_enabled: boolean;
+  weekly_email_enabled: boolean;
+  weekly_email_time?: string;
+}
+
+export interface TwoFactorSetup {
+  secret: string;
+  qr_code: string;
+  backup_codes: string[];
+}
+
+export interface BackupCodesResponse {
+  backup_codes: string[];
+}
+
+// =====================================================
+// IMPORT/EXPORT TYPES
+// =====================================================
+
+export interface ValidationResult {
+  valid: boolean;
+  total_events: number;
+  filled_events?: number;
+  pending_events?: number;
+  unique_symbols: number;
+  date_range: {
+    earliest: string | null;
+    latest: string | null;
+  };
+  errors: ValidationError[];
+  warnings: ValidationError[];
+}
+
+export interface ImportResult {
+  success: boolean;
+  message: string;
+  stats?: {
+    positionsProcessed: number;
+    eventsCreated: number;
+    duration: number;
+  };
+  errors?: string[];
+}
+
+// =====================================================
+// DASHBOARD & ANALYTICS TYPES
+// =====================================================
+
+export interface DashboardData {
+  totalTrades: number;
+  openTrades: number;
+  winRate: number;
+  profitLoss: number;
+  equityCurve: Array<{ date: string; equity: number }>;
+  setupPerformance: Array<{ name: string; value: number; color: string }>;
+  recentTrades: Array<{
+    id: number;
+    ticker: string;
+    entryDate: string;
+    status: string;
+    profitLoss: number | null;
+  }>;
+}
+
+export interface LifetimeTickerAnalytics {
+  ticker: string;
+  totalPositions: number;
+  lifetimeWinRate: number;
+  lifetimePnL: number;
+  averageReturnPerPosition: number;
+  bestPosition: {
+    id: number;
+    returnPercent: number;
+    pnl: number;
+    daysHeld: number;
+  } | null;
+  worstPosition: {
+    id: number;
+    returnPercent: number;
+    pnl: number;
+    daysHeld: number;
+  } | null;
+  averageDaysHeld: number;
+  totalVolumeTraded: number;
+  successByStrategy: Array<{
+    strategy: string;
+    winRate: number;
+    avgReturn: number;
+    positionsCount: number;
+  }>;
+  riskAdjustedReturn: number;
+  openPositionsCount: number;
+  closedPositionsCount: number;
+}
+
+// =====================================================
+// DEBUG & TESTING TYPES
+// =====================================================
+
+export interface ApiConnectionStatus {
+  status: 'success' | 'error';
+  message: string;
+}
+
+export interface AuthStatusResponse {
+  status: 'authenticated' | 'unauthenticated' | 'error';
+  message: string;
+  tokenExists?: boolean;
+  tokenValue?: string;
+  error?: string;
+}
+
+export interface AnalyticsDebugData {
+  [key: string]: unknown;
+}
+
+// =====================================================
+// NOTES TYPES
+// =====================================================
+
+export interface NotesUpdateResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface ProfilePictureUploadResponse {
+  profile_picture_url: string;
+}
+
+// =====================================================
+// GENERIC RESPONSE TYPES
+// =====================================================
+
+export interface SuccessResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  per_page: number;
+  pages: number;
+}
+
+// =====================================================
+// CACHE TYPES
+// =====================================================
+
+export interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+  ttl: number;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting - Strict Mode Enabled */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    
+    /* Additional Options */
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}


### PR DESCRIPTION
* Refactor the frontend service layer to centralize and standardize API type definitions. 

* Move interface/type definitions from individual service files to a shared `types/api` module, updates imports accordingly, and re-exports types for backward compatibility. Additionally, error handling is improved across services by consistently using a shared `AxiosErrorResponse` type. Some service functions are updated to use more precise return types, and minor code improvements are made for clarity and maintainability.

* Moved all API-related interfaces and types from individual service files (e.g., `authService.ts`, `positionsService.ts`, `journalService.ts`, etc.) to a shared module `types/api`, and updated imports to reference the shared types. Types are re-exported from services for backward compatibility. 

* Updated all service functions to use the shared `AxiosErrorResponse` type for error handling, replacing ad-hoc or `any` error typings. This improves error logging and ensures consistent error messages across authentication, notification, debug, and other services.

* Updated function signatures to use more precise types from the shared module, e.g., `testApiConnection` now returns `ApiConnectionStatus`, and analytics/debug/auth functions return their respective types. 
* Refactored cache implementation in `positionsService.ts` to use a generic `CacheEntry` type for better type safety.

* Provided legacy type transformation helpers (`positionToLegacyTrade`, `eventToPartialExit`) with improved typings to support gradual migration of components to the new API type system. 

* Cleaned up redundant code and improved parameter typings in utility functions (e.g., cache key generation and event transformation)